### PR TITLE
WP-1493 prepare for react 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ cache:
   directories:
     - node_modules
 node_js:
-  - '4'
+  - '6'
   - stable
 after_success: >-
   travis-after-all && npm run semantic-release && npm run pages -- --repo

--- a/package.json
+++ b/package.json
@@ -99,9 +99,12 @@
       "stylelint-config-strict"
     ]
   },
+  "peerDependencies": {
+    "react": "^0.14.8||^15.0.0||^16.0.0",
+    "react-dom": "^0.14.8||^15.0.0||^16.0.0"
+  },
   "dependencies": {
-    "react": "^0.14.8||^15.0.0",
-    "react-dom": "^0.14.8||^15.0.0",
+    "prop-types": "^15.5.0",
     "stickyfill": "^1.1.1"
   },
   "devDependencies": {
@@ -118,10 +121,11 @@
     "browserify": "^13.0.0",
     "browserify-istanbul": "^2.0.0",
     "chai": "^3.5.0",
-    "chai-enzyme": "^0.4.2",
+    "chai-enzyme": "^1.0.0-beta.0",
     "chai-spies": "^0.7.1",
     "coveralls": "^2.11.9",
-    "enzyme": "^2.2.0",
+    "enzyme": "^3.0.0",
+    "enzyme-adapter-react-16": "^1.0.1",
     "eslint": "^2.8.0",
     "eslint-config-strict": "^8.5.1",
     "eslint-config-strict-react": "^8.0.1",
@@ -150,7 +154,8 @@
     "postcss-import": "^8.1.0",
     "postcss-reporter": "^1.3.3",
     "postcss-url": "^5.1.1",
-    "react-addons-test-utils": "^0.14.8||^15.0.0",
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "semantic-release": "^4.3.5",
     "stylelint": "^6.2.2",
     "stylelint-config-strict": "^5.0.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,16 +1,9 @@
 import React from 'react';
 import { findDOMNode } from 'react-dom';
+import PropTypes from 'prop-types';
 import Stickyfill from 'stickyfill';
 let stickyfill = null;
 export default class Sticky extends React.Component {
-
-  static get defaultProps() {
-    return {
-      className: '',
-      tag: 'div',
-    };
-  }
-
   componentDidMount() {
     if (stickyfill === null) {
       stickyfill = Stickyfill();
@@ -43,10 +36,15 @@ export default class Sticky extends React.Component {
   }
 }
 
+Sticky.defaultProps = {
+  className: '',
+  tag: 'div',
+};
+
 if (process.env.NODE_ENV !== 'production') {
   Sticky.propTypes = {
-    className: React.PropTypes.string,
-    tag: React.PropTypes.string,
-    children: React.PropTypes.node.isRequired,
+    className: PropTypes.string,
+    tag: PropTypes.string,
+    children: PropTypes.node.isRequired,
   };
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,9 +1,12 @@
 import 'babel-polyfill';
 import Stickyfill from '../src';
 import React from 'react';
+import Enzyme from 'enzyme';
+import Adapter from 'enzyme-adapter-react-16';
 import chai from 'chai';
 import chaiEnzyme from 'chai-enzyme';
 import { mount } from 'enzyme';
+Enzyme.configure({ adapter: new Adapter() });
 chai.use(chaiEnzyme()).should();
 describe('Stickyfill', () => {
 


### PR DESCRIPTION
A few notes from me:

- `enzyme` and `chai-enzyme` used in the tests, so they have been upgraded.
- The component's logic actually depends on `react-dom`, so moved to peer deps with relaxed version requirements.
- In the name of consistency I made `defaultProps` a property of the class rather than static getter.